### PR TITLE
Remove deprecated .Now call

### DIFF
--- a/themes/sendence-hugo-steam-theme/layouts/partials/footer.html
+++ b/themes/sendence-hugo-steam-theme/layouts/partials/footer.html
@@ -2,6 +2,6 @@
 	<div class="inner">
 		{{ partial "social" . }}
 
-		<section class="copyright">&copy; {{.Now.Format "2006"}} <a href="{{ .Site.BaseURL }}">{{ .Site.Params.name }}</a>. {{ .Site.Params.copyright | markdownify }}</section>
+		<section class="copyright">&copy; {{now.Format "2006"}} <a href="{{ .Site.BaseURL }}">{{ .Site.Params.name }}</a>. {{ .Site.Params.copyright | markdownify }}</section>
 	</div>
 </footer>


### PR DESCRIPTION
It has been replaced by `now`. Leaving the deprecated code in causes
hugo to return an exit code that fails our Travis builds.