### PR TITLE
Update licensing information to full Apache 2.0

### DIFF
--- a/content/post/how-to-open-source.md
+++ b/content/post/how-to-open-source.md
@@ -15,10 +15,10 @@ tags = [
 categories = [
     "Our Startup Experience"
 ]
-+++ 
-I’m Vid Jain, CEO & Founder of [Wallaroo Labs](https://www.wallaroolabs.com/). I’m writing today to tell you about how we open-sourced Wallaroo, our software framework for data processing, and the lessons we learned along the way. Our engineering team was experienced at writing great software, but now we faced a new set of challenges. None of us had open-sourced enterprise software before. There are ten key things we did that overcame the barriers and got all our code into the open in just 60 days. 
++++
+I’m Vid Jain, CEO & Founder of [Wallaroo Labs](https://www.wallaroolabs.com/). I’m writing today to tell you about how we open-sourced Wallaroo, our software framework for data processing, and the lessons we learned along the way. Our engineering team was experienced at writing great software, but now we faced a new set of challenges. None of us had open-sourced enterprise software before. There are ten key things we did that overcame the barriers and got all our code into the open in just 60 days.
 
-We had been hard at work for 18 months on Wallaroo, with the goal of open-sourcing it. For 18 months we had many serious discussions as a group about our open-source plans. Then we got funding from several VCs with open-source as a core business strategy, so now we had to do it, and do it well and fast. I feel confident we did a great job. At a recent board meeting, one investor said, “Hey, Vid, that’s a great story.”  
+We had been hard at work for 18 months on Wallaroo, with the goal of open-sourcing it. For 18 months we had many serious discussions as a group about our open-source plans. Then we got funding from several VCs with open-source as a core business strategy, so now we had to do it, and do it well and fast. I feel confident we did a great job. At a recent board meeting, one investor said, “Hey, Vid, that’s a great story.”
 
 I wanted to share this below. Be warned it’s a LOT more effort than might be expected, and balancing our goal of building a developer community with our commercial interests created many heated discussions. I hope this post is helpful and that you check out Wallaroo at [WallarooLabs.com](https://www.wallaroolabs.com/). It lets you build and operate fast data, big data and AI applications that deploy rapidly, scale automatically and run at very low-cost. Our Github repository for [native Python](https://blog.wallaroolabs.com/2017/10/go-python-go-stream-processing-for-python/) is at [https://github.com/WallarooLabs/wallaroo](https://github.com/WallarooLabs/wallaroo), and our community page is [here](https://www.wallaroolabs.com/community). Please try it out and give us feedback.
 
@@ -29,36 +29,36 @@ The ultimate responsibility fell on me, but it goes without saying that you need
 ## 2. Don’t re-invent the wheel.
 
 Get advisors who've done it before and look at similar companies and their strategies. The most important question I got from an advisor was: “What’s your goal in open-sourcing?” For example, if your goal is to make $100MM a year, that leads to a different strategy than aiming for a huge market share. Expect the process of answering questions and getting feedback from your advisors to be iterative. Meet frequently with your team and devote significant time to understanding what you want to achieve and how you might go about it.
- 
+
 ## 3. Hire a software-licensing attorney with relevant experience.
 
 We wanted to create a commercial business, and I didn’t want to base critical decisions on just my knowledge. Ask around for recommendations for attorneys, talk to several, and go with experience and what your gut tells you. I spoke to five attorneys before getting the same recommendation from both Cockroach Labs and from an investor in MongoDB. We went with an attorney from Gunderson Dettmer that a group of us liked, and it turned out great.
- 
- 
+
+
 ## 4. Make sure executive, marketing, and engineering are in agreement about goals.
 
 Sounds obvious, but it’s effort to get there. Often, you’re all using the same terms but mean different things. Eventually, we were able to agree on our goals and the language we used to describe them. For example, what do you mean when you say “open-source” vs. “community license,” or what’s actually in the open-source version of the software. Does it include, e.g., the tools you use to test your software or the UI you use to monitor performance?
- 
+
 ## 5. Determine what customers will pay you for.
 
 If your goal is to generate revenue, this is a key question, and the first answer may not be right. You have to figure out who your paying customers are, their use-cases, and where you fit in. For us, our customers are startups, medium and large enterprises, and cloud-based service providers. Our key value is in significantly reducing the complexity and cost of deploying data applications at large scale.
- 
+
 ## 6. Design a licensing strategy to lets many developers use it, with dials for monetizing.
 
 Again, if your goal is commercial, then you will have to balance two drivers. On the one hand, you want to get as many developers as possible trying and using your product. On the other, you want users who are getting the most value to give some of that back to you as revenue. Where to draw that line between the two is going to involve experimentation (unless your business is solely a support business). So build in some dials that you can turn. In our case, one dial is the number of servers that Wallaroo is deployed with for advanced features.
- 
+
 ## 7. Work on your licenses and support agreements.
 
 Now that you’ve decided on what you want to fully open-source, and what you want to make money on, you’ve got a lot of work. In addition to the license for the open-source part, you need a contributor’s agreement, a community or commercial software license, and a commercial use and support agreement. This is where that great attorney you hired is instrumental - but don’t just leave it up to her. Ask a lot of questions and make sure it makes sense to your team.
- 
+
 ## 8. Work on improving user experience.
 
 Outside developers are going to need excellent documentation, examples, tutorials, and easy installation. Make sure you’ve thought these through and don’t hesitate to ask friends to give critical feedback. We had an outside developer evangelist go through our website and documents, and we had a soft-launch where developer friends gave us feedback on installation and using the software.
- 
+
 ## 9. Work on the website and your community page.
 
 You need to explain what your software does and give access to all the [supporting materials](https://www.wallaroolabs.com/community). Don’t leave this to the end because your first version of everything will need to be reworked. In our case, we had constant revisions over 3 weeks. And what’s the goal? Is it to drive visitors to your community page or documentation, is it to get developers to your GitHub repository, or is to have developers spend a lot of time on your website?
- 
+
 ## 10. Cleanup code, refactor if needed, add tags.
 
 Expect to devote a significant amount of developer effort to this. In our case, we had to decide on a file-by-file basis what license the code was getting, and we had to move the code into a different directory structure. Once done, check again. We had two engineers working on this for a month, and it impacted other projects (it’s hard to change the engine in a moving car).
@@ -67,12 +67,12 @@ Expect to devote a significant amount of developer effort to this. In our case, 
 
 If you think you’ve gotten everything perfect, you’ve spent too much time on it. Once it’s out in the open, you’re going to get a ton of feedback on everything from your website to your documentation, to use-cases, and the actual product. Not everything will line up with what you think is perfect.
 
-For us, our understanding of what we meant when we said “open-source” evolved to include not just software released under a standard open-source license, but also code available under a more restrictive license. In the end, we released the core Wallaroo product under Apache 2.0 and additional advanced features under the [Wallaroo community license](https://www.wallaroolabs.com/wallaroo-community-license).
+For us, our understanding of what we meant when we said “open-source” evolved to include not just software released under a standard open-source license, but also code available under a more restrictive license. Initially we released the core Wallaroo product under Apache 2.0 and additional advanced features under the Wallaroo community license, but now all of Wallaroo is available under Apache 2.0.
 
-My colleague Chuck Blake will cover what you need to do once it’s open-source in an upcoming post - you’ve just gotten started. 
+My colleague Chuck Blake will cover what you need to do once it’s open-source in an upcoming post - you’ve just gotten started.
 
 ## Give Wallaroo a try
 
 We’re excited to start working with our friends in the open-source community and new commercial partners.
 
-If you are interested in getting started with Wallaroo, head over to [our website and get started](https://www.wallaroolabs.com/community). And if this post sparked your curiosity and you want to talk more, please contact me at [Vid.Jain@WallarooLabs.com](mailto:Vid.Jain@WallarooLabs.com). 
+If you are interested in getting started with Wallaroo, head over to [our website and get started](https://www.wallaroolabs.com/community). And if this post sparked your curiosity and you want to talk more, please contact me at [Vid.Jain@WallarooLabs.com](mailto:Vid.Jain@WallarooLabs.com).

--- a/content/post/open-sourcing-wallaroo.md
+++ b/content/post/open-sourcing-wallaroo.md
@@ -17,7 +17,7 @@ I'm very excited to announce the first open source, public release of our ultraf
 
 ## What is Wallaroo?
 
-Wallaroo is an ultrafast and elastic data processing engine that rapidly takes you from prototype to production by making the infrastructure virtually disappear.  We’ve designed it to handle demanding high-throughput, low-latency tasks where the accuracy of results is essential. Wallaroo takes care of mechanics of scaling, resilience, state management, and message delivery. We've designed Wallaroo to make it easy to scale applications with no code changes, and allow programmers to focus on business logic. If you are interested in learning more about Wallaroo, I suggest you start with our introductory blog post ["Hello Wallaroo!" blog post][hello wallaroo post] that we released back in March. 
+Wallaroo is an ultrafast and elastic data processing engine that rapidly takes you from prototype to production by making the infrastructure virtually disappear.  We’ve designed it to handle demanding high-throughput, low-latency tasks where the accuracy of results is essential. Wallaroo takes care of mechanics of scaling, resilience, state management, and message delivery. We've designed Wallaroo to make it easy to scale applications with no code changes, and allow programmers to focus on business logic. If you are interested in learning more about Wallaroo, I suggest you start with our introductory blog post ["Hello Wallaroo!" blog post][hello wallaroo post] that we released back in March.
 
 I've done a [15-minute video of our engineering presentation][scale independence with wallaroo] that has helped people understand what Wallaroo is. If you watch it, you will get:
 
@@ -42,7 +42,7 @@ As our CEO Vid Jain puts it:
 
 And that's what we are looking at every day. Our engineers are always asking themselves, does this feature:
 
-- Make it easier to scale an application? 
+- Make it easier to scale an application?
 - Push the burden of scaling a distributed application from the developer to the framework?
 - Improve performance?
 - Increase a developer's productivity?
@@ -51,7 +51,7 @@ And that's what we are looking at every day. Our engineers are always asking the
 Part of that means that we want to allow developers to use the languages they are used to. The big data landscape is dominated by projects that require you to use the JVM. The JVM is an impressive piece of technology, but it's not for everyone.  To that end, we are launching with a Python API, followed by C++ and Go bindings in the near future. We think that data scientists shouldn't have to rewrite the application they developed in Python to get it into production. The same would apply to C++ and Go; everyone deserves great tools. We're here to provide them to more folks.
 
 So, that's what we are building. But, what's the state of Wallaroo now and where is it going in the immediate future?
- 
+
 ## What's the current state?
 
 Wallaroo has a solid core in place that can be immediately useful for some production workflows now. We do [extensive testing][codemesh16 how did i get here] of Wallaroo that we continue to expand on and improve. Through both internal testing usage and via customer proof of concept engagements, Wallaroo has already processed billions of messages in a single day.
@@ -60,15 +60,15 @@ With our open source release you get:
 
 - A Python 2.7 API for building linear data processing applications
 - [Documentation][documentation website] to get you started
-- Integrated state-management 
+- Integrated state-management
 - Process failure recovery
 - Ability to take your application from running on one process to many without changing code
 - Metrics UI
 
 Wallaroo has been used to build a variety of applications including:
 
-- High-volume position keeping system (using our C++ API, slated for GA in the near future) 
-- Python video transcription and analysis system using TensorFlow and NLP 
+- High-volume position keeping system (using our C++ API, slated for GA in the near future)
+- Python video transcription and analysis system using TensorFlow and NLP
 
 We're looking to work with commercial partners and the open source community to grow the product in line with our vision. We've come a long way from where we started eighteen months ago, and we know there's plenty more to do; software is never done. The problems Wallaroo aims to solve will continue to grow and change. So what are we planning on doing with Wallaroo over the next few months?
 
@@ -86,21 +86,11 @@ If you are interested in more details, check out our [roadmap][roadmap].
 
 ## Licensing
 
-Wallaroo is an open source project. All of the source code is available to you. However, not all of the Wallaroo source code is available under an "open source" license. 
-
-Most of the Wallaroo code base is available under the [Apache License, version 2][apache 2 license]. Parts of Wallaroo are licensed under the [Wallaroo Community License Agreement][wallaroo community license]. The [Wallaroo Community License][wallaroo community license] is based on [Apache version 2][apache 2 license]. However, you should read it for yourself. Here we provide a summary of the main points of the [Wallaroo Community License Agreement][wallaroo community license].
-
-- You can **run** all Wallaroo code in a non-production environment without restriction.
-- You can **run** all Wallaroo code in a production environment for free on up to 3 servers or 24 CPUs.
-- If you want to **run** Wallaroo Enterprise version features in production above 3 servers or 24 CPUs, you have to obtain a license.
-- You can **modify** and **redistribute** any Wallaroo code
-- Anyone who uses your **modified** or **redistributed** code is bound by the same license and needs to obtain a Wallaroo Enterprise license to run on more than 3 servers or 24 CPUs in a production environment. 
-
-Please [contact us][contact us email] if you have any questions about licensing or Wallaroo Enterprise.
+Wallaroo is an open source project. All of the source code is available to you. The code base is available under the [Apache License, version 2][apache 2 license]. In earlier version of Wallaroo some parts were licensed under the Wallaroo Community License Agreement, but the Apache 2.0 license now covers all of the code.
 
 ## Give Wallaroo a try
 
-We're excited to start working with our friends in the open source community and new commercial partners. 
+We're excited to start working with our friends in the open source community and new commercial partners.
 
 If you are interested in getting started with Wallaroo, head over to [our website and get started][website community section]. If you would like a demo or to talk about how Wallaroo can help your business, please get in touch by emailing [hello@wallaroolabs.com][contact us email].
 

--- a/content/post/questions-answered.md
+++ b/content/post/questions-answered.md
@@ -12,113 +12,104 @@ categories = [
     "FAQ"
 ]
 +++
-Wallaroo Labs has received a lot of great feedback from developers on Hacker News and other communities. 
+Wallaroo Labs has received a lot of great feedback from developers on Hacker News and other communities.
 
 Below are some answers to questions that repeatedly come up in conversations about Wallaroo.
 
 Thank you! Please keep reading our engineering posts, commenting, and asking questions!
 
 ## Why did you write Wallaroo in Pony?
- 
+
 When we looked at the tools available to build Wallaroo and the use cases we wanted to handle, there were a few paths available to us.
- 
+
 We wanted high-throughput and very low-latency processing, so Erlang was going to be a problem. If we wanted to write a runtime from scratch, we could go with C/C++ or maybe Rust. Our other option was to take the plunge with Pony and leverage its runtime.
- 
+
 Writing a lock-free, high-performance runtime for safely accessing data and running multiple threads is no small task, so leveraging the Pony runtime has been a massive win for us. There’s no doubt it was the right choice.
- 
+
 If we didn't use the Pony runtime and had written our own from scratch, we wouldn’t have made progress so quickly. It’s not always easy to figure how much time you didn’t waste, but – if you forced us to put a number on it – we estimate that using the Pony runtime saved us a good 18 months of hard work.
- 
+
 For a more in-depth overview, check out our post: [“Why We Used Pony to Write Wallaroo.”](https://blog.wallaroolabs.com/2017/10/why-we-used-pony-to-write-wallaroo/)
- 
+
 ## What types of tasks are well-suited for Wallaroo?
- 
+
 Wallaroo is built for applications that process data on an event-by-event basis, operate at high-throughput, and demand low-latency.
- 
+
 Additionally, we offer native Python support, so you don't need to run on top of Java/JVM. This makes Wallaroo a great choice to vs. other stream processing frameworks that run on the JVM like Apache Storm, Spark, or Flink.
- 
-Wallaroo can handle any use case that a stream processing system can handle, covering a variety of use cases within a range of industries and verticals including medical cybersecurity, infrastructure monitoring, programmatic advertising, location services, and manufacturing.  [o1] 
- 
+
+Wallaroo can handle any use case that a stream processing system can handle, covering a variety of use cases within a range of industries and verticals including medical cybersecurity, infrastructure monitoring, programmatic advertising, location services, and manufacturing.  [o1]
+
 ## Is Wallaroo used in production?
- 
+
 We are working with several clients on applications including use cases in infrastructure monitoring, cybersecurity, and streaming workflows.
- 
+
 Currently, none of these Wallaroo installations are in production, but we expect several of them to be live by spring of 2018.
- 
+
 We’ll keep you posted on our progress.
 ## How does Wallaroo compare to other stream processing frameworks?
- 
+
 Wallaroo was built to handle the ever-increasing demands of data-driven applications. On an event-by-event basis (not micro-batching), we’ve seen sustained, end-to-end latency as low as two microseconds. .
- 
+
 We know that you have many stream processing frameworks to choose from, so you want to know what makes Wallaroo special. Here are the areas in which Wallaroo excels.
- 
+
 ### Stateful Applications
 Wallaroo has a built-in resilient in-memory resilient state; you don't need to roll your own or use a secondary system to keep state.
- 
+
 ### Python and Golang are first-class citizens.
 Wallaroo lets you program natively in Python and Golang, using your favorite tools and libraries.  Wallaroo is perfect for organizations that don’t want to deal with the complexity of JVM-based solutions.
- 
+
 ### High-performance
 Wallaroo was conceived while working on consulting projects for a large bank’s electronic trading systems.  High-throughput and low-latency were the core goals of Wallaroo – goals that we have achieved wonderfully.
- 
+
 ### Scalability
 Using Wallaroo's scale-independent API, you can write code once and deploy on any infrastructure at any scale.
- 
+
 If any of these benefits pique your interest, Wallaroo is an excellent choice for you.
+
 ## How do you ingest data with Wallaroo? What sources and sinks are supported?
- 
-Wallaroo currently supports TCP and Kafka sources and sinks. We have plans to roll out additional source and sink support soon, prioritized by user and client needs. That’s in addition to an API that allows developers to build their own in Python and Golang, which you can also expect to see in the near future. 
+
+Wallaroo currently supports TCP and Kafka sources and sinks. We have plans to roll out additional source and sink support soon, prioritized by user and client needs. That’s in addition to an API that allows developers to build their own in Python and Golang, which you can also expect to see in the near future.
+
 ## How is Wallaroo licensed?
- 
-Wallaroo is an open source project, so all of the source code is available to you.
- 
-Most of the Wallaroo code base is available under the Apache License, version 2. However, parts of Wallaroo are licensed under the Wallaroo Community License Agreement. Our source files include a header indicating which license applies to each file.
- 
-The core stream processing engine and state management facilities are all licensed under the Apache License, version 2. Autoscaling, exactly-once message processing, and resiliency features are licensed under the Wallaroo Community License Agreement.
- 
-The Wallaroo Community License is based on Apache, version 2. However, you should read it for yourself. Here we provide a summary of the main points of the Wallaroo Community License Agreement:
- 
-* You may run all Wallaroo code in a non-production environment without restriction.
-* You may run all Wallaroo code in a production environment for free on up to 3 servers or 24 CPUs .
-* If you want to run Wallaroo Enterprise version features in production above 3 servers or 24 CPUs, you must obtain a license.
-* You may modify and redistribute any Wallaroo code.
-* Anyone who uses your modified or redistributed code is bound by the same license and must obtain a Wallaroo Enterprise license to run on more than 3 servers or 24 CPUs in a production environment.
+
+Wallaroo is an open source project, so all of the source code is available to you. It is available under the Apache License, version 2. Parts of earlier versions of Wallaroo were released under a more restrictive Wallaroo Community License, but now these pieces are under the Apache License as well.
+
 ## How does Wallaroo measure latency?
- 
-In Wallaroo, we measure the time it takes to process every message within the system.  
- 
-Much [thought](https://blog.wallaroolabs.com/2018/02/building-low-overhead-metrics-collection-for-high-performance-systems/) went into how we go about capturing detailed latency statistics while minimizing the impact on the system's performance.  
- 
+
+In Wallaroo, we measure the time it takes to process every message within the system.
+
+Much [thought](https://blog.wallaroolabs.com/2018/02/building-low-overhead-metrics-collection-for-high-performance-systems/) went into how we go about capturing detailed latency statistics while minimizing the impact on the system's performance.
+
 The Wallaroo UI shows the latency of message processing for the last five minutes.  The UI reports latency in the following percentiles: 50%, 95%, 99%, 99.9% and 99.99%.  These latency numbers are visible overall for a pipeline, as well as broken down to works and computations, the individual components of the pipeline.
- 
+
 We believe that by providing meaningful metrics via the Wallaroo UI and allowing developers to identify specific bottlenecks in computations or other parts of our system, they will be able to make quick iterations in their development cycle.
- 
+
 ## What are Wallaroo’s current limitations and how are you planning on addressing them?
- 
+
 The current state of Wallaroo provides a great set of features and functionality that target a wide variety of use cases.  That being said, Wallaroo is a work in progress, and we expect there to always be open issues as we move the state of the art forward.
- 
+
 The most current and up-to-date- information on the limitations of Wallaroo are located [here](https://github.com/WallarooLabs/wallaroo/blob/master/LIMITATIONS.md).
- 
+
 We prioritize issues and new feature requests according to the needs of our clients and most active users. If there is something that you would like to see addressed, please speak up. You can [open an issue](https://github.com/WallarooLabs/wallaroo/issues) or ping us on [IRC](https://webchat.freenode.net/?channels=#wallaroo).
 ## What windowing strategies does Wallaroo support?
- 
+
 Wallaroo currently supports event-driven windowing, in which the boundaries of each window are determined outside of Wallaroo and triggered by any event. Wallaroo is told when a window ends, and work is run on the aggregate state and started over.
- 
+
 A detailed example of event-driven windowing in Wallaroo is available [here](https://blog.wallaroolabs.com/2017/11/non-native-event-driven-windowing-in-wallaroo/).
- 
-We will be rolling out support for additional windowing use cases as needed to support our clients.  
+
+We will be rolling out support for additional windowing use cases as needed to support our clients.
 ## Where did the name Wallaroo come from?
- 
+
 Picking the correct name is important, and a whole lot of fun!
- 
+
 When we began building our high-performance stream processing framework, we called the project Buffy, an ode to "Buffy the Vampire Slayer." The idea was that we could call the framework Buffy and name its various components after other characters from the show.  Some of those references, such as Giles and Spike, live on in our code.
- 
+
 As our company progressed, we considered the idea of open-sourcing our software, and decided to take the opportunity to come up with a better name.
- 
+
 Internally, we started to toss around lots of new ideas. Many names were suggested only to be batted down.  Warp? Nope, too generic. Arkwright? Too obscure. We tried the names of scientists, such as Heisenberg, but decided that associating our framework and its accurate results with his “uncertainty principle” might have been a poor marketing decision.
- 
+
 After all of that, we tried animal names. Of those chosen, "Wallaroo" quickly became a frontrunner.  It was one of the top five names that we came up with internally, and our CEO, Vid Jain, made it official when he made the final selection.
- 
-We’re quite happy with the name, but we’re particularly proud of the logo. The Wallaroo platform is perfectly represented by the unassuming animal outfitted with boxing gloves. 
+
+We’re quite happy with the name, but we’re particularly proud of the logo. The Wallaroo platform is perfectly represented by the unassuming animal outfitted with boxing gloves.
 
 Simple, powerful, and ready for a fight!
 
@@ -136,4 +127,3 @@ Some other great ways to learn about Wallaroo:
 * [Wallaroo Community](https://www.wallaroolabs.com/community)
 
 Thank you! We always appreciate your candid feedback (and a [GitHub star](https://github.com/WallarooLabs/wallaroo))!
-


### PR DESCRIPTION
Parts of Wallaroo had been released under a Wallaroo Community
License, but we have now moved the entire project to Apache 2.0. Some
of our blog posts discussed licensing, so we've updated them in order
to make sure that people who find our blog posts have up-to-date
information about licensing.

This change should not be merge in until 0.5.3 has been released.