### PR TITLE
Support using url slugs with our posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ When you create a blog post using the above instructions, standard Wallaroo Labs
 ```toml
 +++
 title = "example"
+slug = "example"
 draft = false
 date = "2017-03-02T15:20:13-05:00"
 categories = ["category 1","category 2"]
@@ -53,6 +54,7 @@ author = "Author Name"
 Let's quickly run through each.
 
 * Title is the title of your post
+* Slug, if supplied, is what will appear as the "post title" in the URL. Using a meaningful slug allows you do change the title later without changing the post URL.
 * Leave draft as false. That way it will appear in Netlify previews and on the site when we merge our PR.
 * Date you should date to the current date and time right before your PR is merged.
 * Categories are used to group a series of posts together. For example, our series of posts introducing the world to Wallaroo is under the category "Hello Wallaroo". Categories should be used for a related series of posts that you would expect benefit from being read in order. You can [check the website](http://blog.wallaroolabs.com/categories/) to see existing categories.

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,5 +1,6 @@
 +++
 title = "{{ replace .TranslationBaseName "-" " " | title }}"
+slug = "{{ replace .TranslationBaseName "-" " " | title }}"
 date = {{ .Date }}
 draft = false
 author = "Author Name"

--- a/config.toml
+++ b/config.toml
@@ -8,7 +8,7 @@ googleAnalytics = ""
 paginate = 5
 
 [permalinks]
-  post = "/:year/:month/:title/"
+  post = "/:year/:month/:slug/"
 
 [params]
 	title = "Wallaroo Labs Engineering Blog"

--- a/content/post/performance-metrics-overview.md
+++ b/content/post/performance-metrics-overview.md
@@ -2,7 +2,6 @@
 title = "Building low-overhead metrics collection for high-performance systems"
 date = 2018-02-20T07:20:00-05:00
 draft = false
-slug = "building-low-overhead-metrics-collection-for-high-performance-systems"
 author = "jonbrwn"
 description = "Design decisions that allowed us to capture metrics in Wallaroo with a low-overhead."
 tags = [


### PR DESCRIPTION
Having the post url change if we decide to rename the post later sucks.
This change introduces an optional slug. If not provided, the standard
"generated from title" URL scheme will be used as it currently is.